### PR TITLE
Support reading from stdin

### DIFF
--- a/webtable_to_text.rb
+++ b/webtable_to_text.rb
@@ -11,12 +11,19 @@ require_relative 'libhtmltable.rb'
 
 options = {}
 OptionParser.new do |opts|
-  opts.banner = "  Usage: webtable_to_text.rb [options]"
+  opts.banner = <<BANNER
+ usage:
+   webtable_to_text.rb [options] [-f FILE | -u URL]
+   curl [options] URL | webtable_to_text.rb
+   wget -O- [options] URL | webtable_to_text.rb
+
+ options:
+BANNER
 
   opts.on("-A", "--all", "Print all tables found on the specified page") { options[:all] = true }
   opts.on("-a", "--asciidoc", "Output in asciidoc/asciidoctor format") { options[:asciidoc] = true }
   opts.on("-c", "--csv", "Output in CSV / comma separated values format") { options[:csv] = true }
-  opts.on("-f", "--file FILE", "Specify HTML input file as source for extracting tables") { |v| options[:file] = v }
+  opts.on("-f", "--file FILE", "Specify HTML input file as source for extracting tables; use '-' to read from stdin") { |v| options[:file] = v }
   opts.on("-i", "--interactive", "Interactive mode") { options[:interactive] = true }
   opts.on("-m", "--markdown", "Output in markdown format") { options[:markdown] = true }
   opts.on("-n", "--number NUM", "Print specific table number only; separate multiple numbers with commas") { |v| options[:number] = v }
@@ -27,8 +34,6 @@ OptionParser.new do |opts|
 
 end.parse!
 
-source = ""
-
 url = options[:url]
 file = options[:file]
 
@@ -38,9 +43,15 @@ if url
   source_content = URI.open(escaped).read
 elsif file
   source_location = file
-  source_content = File.read(file)
+  if file == "-"
+    # h/t: https://stackoverflow.com/a/273841
+    source_content = ARGF.read
+  else
+    source_content = File.read(file)
+  end
 else
-  abort("  Please provide a source file or URL as input")
+  #abort("  Please provide a source file or URL as input")
+  source_content = ARGF.read
 end
 
 doc = Nokogiri::HTML(source_content)

--- a/webtable_to_text.rb
+++ b/webtable_to_text.rb
@@ -50,7 +50,13 @@ elsif file
     source_content = File.read(file)
   end
 else
-  #abort("  Please provide a source file or URL as input")
+  if $stdin.isatty
+    abort("  Please provide a source file or URL as input. See '--help'.")
+  end
+  if options[:interactive]
+    abort("  Interactive mode not supported when reading from a pipe.")
+  end
+  source_location = '(stdin)'
   source_content = ARGF.read
 end
 
@@ -60,7 +66,7 @@ tables = doc.xpath('//table')
 len = tables.length
 
 if len < 1
-  abort("  No tables found in page at #{source_location}")
+  abort("  No tables found in page at #{source_location}.")
 end
 
 numstring = "all"


### PR DESCRIPTION
Thanks for releasing this out into the world. Works as advertised, no muss, no fuss.

"Give me the first column from an HTML table" _seems_ like a thing that lots of people would want to do. I'm surprised at the apparent dearth of tools for that task. Maybe the world moved to XML, and then JSON, and I missed the moment. Surprised that [pup](https://github.com/ericchiang/pup), [xidel](https://www.videlibri.de/xidel.html), [htmlq](mgdm/htmlq), or one of those didn't already _do_ this—at least not in a straightforward manner.

I know you put some effort into loading the URL using the Ruby facilities for that, but I was already using `curl` to handle authentication to an internal site, and so reading from standard input seemed like the appropriate, Unixy thing to do.

Nowadays, even Windows has a `curl`, which is probably just a wrapper around some PowerShell `Get-URL` or whatever like that.